### PR TITLE
OpenVPN: cycle through VPN configs

### DIFF
--- a/payloads/library/remote-access/openvpn/payload.sh
+++ b/payloads/library/remote-access/openvpn/payload.sh
@@ -1,16 +1,16 @@
 #!/bin/bash
 #
-# Title:		OpenVPN
-# Description:	Create a VPN connection to an OpenVPN server. Optionally, send
-# 				traffic from the clients through said tunnel.
-# Author: 		Hak5
-# Version:		1.1
-# Category: 	remote-access
-# Target: 		Any
-# Net Mode:		BRIDGE, VPN
+# Title:        OpenVPN
+# Description:  Create a VPN connection to an OpenVPN server. Optionally, send
+#               traffic from the clients through said tunnel.
+# Author:       Hak5
+# Version:      1.1
+# Category:     remote-access
+# Target:       Any
+# Net Mode:     BRIDGE, VPN
 
 # Set to 1 to allow clients to use the VPN
-FOR_CLIENTS=1
+FOR_CLIENTS=0
 
 DNS_SERVER="8.8.8.8"
 

--- a/payloads/library/remote-access/openvpn/payload.sh
+++ b/payloads/library/remote-access/openvpn/payload.sh
@@ -1,15 +1,16 @@
 #!/bin/bash
-# 
+#
 # Title:		OpenVPN
-# Description:	Create a connection to a VPN-connection to an OpenVPN-server. Optionally: Send traffic from the clients through said tunnel.
+# Description:	Create a VPN connection to an OpenVPN server. Optionally, send
+# 				traffic from the clients through said tunnel.
 # Author: 		Hak5
-# Version:		1.0
+# Version:		1.1
 # Category: 	remote-access
 # Target: 		Any
 # Net Mode:		BRIDGE, VPN
 
 # Set to 1 to allow clients to use the VPN
-FOR_CLIENTS=0
+FOR_CLIENTS=1
 
 DNS_SERVER="8.8.8.8"
 
@@ -29,12 +30,9 @@ function start() {
 
 	DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 
-	# Update factory default payload
-	cp ${DIR}/payload.sh /root/payloads/switch3/payload.sh
-
 	# Set NETMODE to BRIDGE and wait 3 seconds
 	# to ensure that things can settle
-	
+
 	[[ "$FOR_CLIENTS" == "1" ]] && {
 		/usr/bin/NETMODE VPN
 	} || {
@@ -56,6 +54,42 @@ function start() {
 	setdns &
 
 	LED ATTACK
+
+	# Cycle between VPN configs when the button is pressed. The default
+	# "config.ovpn" will be loaded on startup, and pressing the button will
+	# cycle through all numbered VPN configs. To use this, add additional VPN
+	# configs named "config1.ovpn", "config2.ovpn", etc.
+	#
+	# If no numbered configs exist, the button functions as a way to reset the
+	# VPN connection.
+	while true; do
+		NO_LED=true BUTTON
+
+		# Stop openvpn and update the LED
+		LED SETUP
+		/etc/init.d/openvpn stop
+
+		# Determine which config to load next
+		configpath=$(uci get openvpn.vpn.config)
+		configfile=$(echo "${configpath}" | grep -Eo 'config[0-9]*')
+		confignumber=$(echo "${configfile}" | grep -Eo '[0-9]*')
+		if [ -z "${confignumber}" ]; then
+			confignumber="0"
+		fi
+		nextconfignumber="$(($confignumber + 1))"
+		if [ -f "${DIR}/config${nextconfignumber}.ovpn" ]; then
+			uci set openvpn.vpn.config="${DIR}/config${nextconfignumber}.ovpn"
+		elif [ -f "${DIR}/config1.ovpn" ]; then
+			uci set openvpn.vpn.config="${DIR}/config1.ovpn"
+		else
+			uci set openvpn.vpn.config="${DIR}/config.ovpn"
+		fi
+		uci commit
+
+		# Start openvpn and update the LED
+		/etc/init.d/openvpn start
+		LED ATTACK
+	done
 }
 
 # Start the payload

--- a/payloads/library/remote-access/openvpn/payload.sh
+++ b/payloads/library/remote-access/openvpn/payload.sh
@@ -30,9 +30,7 @@ function start() {
 
 	DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
 
-	# Set NETMODE to BRIDGE and wait 3 seconds
-	# to ensure that things can settle
-
+	# Set NETMODE to BRIDGE and wait 3 seconds to ensure that things can settle
 	[[ "$FOR_CLIENTS" == "1" ]] && {
 		/usr/bin/NETMODE VPN
 	} || {
@@ -71,8 +69,8 @@ function start() {
 
 		# Determine which config to load next
 		configpath=$(uci get openvpn.vpn.config)
-		configfile=$(echo "${configpath}" | grep -Eo 'config[0-9]*')
-		confignumber=$(echo "${configfile}" | grep -Eo '[0-9]*')
+		configfile=$(echo "${configpath}" | grep -Eo "config[0-9]*")
+		confignumber=$(echo "${configfile}" | grep -Eo "[0-9]*")
 		if [ -z "${confignumber}" ]; then
 			confignumber="0"
 		fi


### PR DESCRIPTION
This PR adds functionality to the button in the OpenVPN payload.

If the button is pressed while using this payload, the payload will stop OpenVPN, switch the config to `config1.ovpn`, and restart OpenVPN. Pressing the button again will switch to `config2.ovpn`, and so on. If no more numbered VPN configs are found, it will loop back to `config1.ovpn`.

If only `config.ovpn` is present, the button will act as a way to quickly reset the VPN connection.